### PR TITLE
Sanitize string as html safe when using ga_tag helper

### DIFF
--- a/lib/gamco/builder.rb
+++ b/lib/gamco/builder.rb
@@ -16,7 +16,7 @@ module Gamco
     def tag(type, event, options = {})
       view.content_tag(:script) do
         dimensions = options.to_json
-        "gtag('#{type}', '#{event}', #{dimensions})"
+        "gtag('#{type}', '#{event}', #{dimensions})".html_safe
       end
     end
 


### PR DESCRIPTION
## Addresses issue: [#TOOL-1](https://amcoit.atlassian.net/browse/TOOL-1)
